### PR TITLE
Fix multiple runs of rbenv role.

### DIFF
--- a/roles/rbenv/tasks/main.yml
+++ b/roles/rbenv/tasks/main.yml
@@ -29,7 +29,7 @@
 # install base version
 
 - name: install and build rubies
-  command: rbenv install {{ item }}
+  command: rbenv install -s {{ item }}
   with_items: rubies
 
 # set the global


### PR DESCRIPTION
Currently the rbenv role doesn't work if a matching ruby is already installed. This sets a flag in the rbenv command so that rbenv just skips installing in this case.
