### PR TITLE
Added new role user_image to set a User's Account Image

### DIFF
--- a/roles/user_image/tasks/main.yml
+++ b/roles/user_image/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# dump the current user image, notify the user, and then remove it
+- name: Backing Up Current Image
+  shell: "dscl . read /Users/{{ ansible_env.USER }} JPEGPhoto | tail +2 | xxd -r -p > /Users/{{ ansible_env.USER }}/Pictures/{{ ansible_env.USER}}_backup.jpg"
+
+- name: Notify User of Backed Up Image
+  debug: "msg='Your existing User Image was backed up to: /Users/{{ ansible_env.USER }}/Pictures/{{ ansible_env.USER}}_backup.jpg'"
+
+- name: Deleting Existing Image
+  command: "dscl . delete /Users/{{ ansible_env.USER }} JPEGPhoto"
+
+# prepare user_image.txt and jpg, then dsimport and show it off
+- name: Copy User Image Template
+  template: "src=user_image.txt dest=/tmp/{{ ansible_env.USER }}.txt"
+
+- name: Importing User Image via Import File
+  command: "dsimport /tmp/{{ ansible_env.USER }}.txt /Local/Default M"
+
+- name: "Opening Users & Group System Pref"
+  command: open /System/Library/PreferencePanes/Accounts.prefpane

--- a/roles/user_image/templates/user_image.txt
+++ b/roles/user_image/templates/user_image.txt
@@ -1,0 +1,2 @@
+0x0A 0x5C 0x3A 0x2C dsRecTypeStandard:Users 2 dsAttrTypeStandard:RecordName externalbinary:dsAttrTypeStandard:JPEGPhoto
+{{ ansible_env.USER }}:{{ ansible_env.PWD }}/{{ image_name }}


### PR DESCRIPTION
Users provide their own jpeg in the root of their xc-custom/ and set
image_path in their all.yml, the role takes care of the rest.  It also
backs up the existing image in case they had already customized it.
