### PR TITLE
fixed homebrew_cask_opts - missing close quote

### DIFF
--- a/roles/homebrew_cask/tasks/main.yml
+++ b/roles/homebrew_cask/tasks/main.yml
@@ -29,7 +29,7 @@
   register: zshenv_present
 
 - name: add homebrew_cask_opts to .zshenv if present
-  lineinfile: dest=~/.zshenv regexp="^export HOMEBREW_CASK_OPTS" line="export HOMEBREW_CASK_OPTS=\"--appdir=/Applications\" state=present backup=yes
+  lineinfile: dest=~/.zshenv regexp="^export HOMEBREW_CASK_OPTS" line="export HOMEBREW_CASK_OPTS=\"--appdir=/Applications\"" state=present backup=yes
   when: zshenv_present.stat.exists == True
 
 # ensure .profile is present at minimum, or update if it exists, when the above fails


### PR DESCRIPTION
homebrew_cask role was failing; could not modify .zshenv due to missing close quote after the 'line' snippet.
