### PR TITLE
role for using apm to install packages for Atom

### DIFF
--- a/roles/atom_package/meta/main.yml
+++ b/roles/atom_package/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: cask_package
+    package_name: atom

--- a/roles/atom_package/tasks/main.yml
+++ b/roles/atom_package/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# install atom plugin
+
+- name: install {{package_name}}
+  shell: /Applications/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install {{ package_name }}

--- a/roles/atom_package/tasks/main.yml
+++ b/roles/atom_package/tasks/main.yml
@@ -2,4 +2,4 @@
 # install atom plugin
 
 - name: install {{package_name}}
-  shell: /Applications/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install {{ package_name }}
+  shell: /Applications/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install {{ package_name }} creates=~/.atom/packages/{{package_name}}


### PR DESCRIPTION
Uses a deep call into Atom's self-contained node install b/c it's likely that 'apm' and 'atom' haven't been symlinked into /usr/local/bin yet.

Looked into doing that symlink for the user, but there were a ton of require.js dependencies to satisfy and this is the simplest way to get this done without shaving yaks.
