### PR TITLE
A role for updating osxc

### DIFF
--- a/roles/osxc/main.yml
+++ b/roles/osxc/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+ - role: git_package
+   repo: github.com/osxc/xc-common


### PR DESCRIPTION
We still need to update osxc manually. That's why I'll try here to make ansible aware of that and update it whenever it's possible !

Feel free to comment if you have any suggestion on this !
