### PR TITLE
Added cask_env_package role to handle missing HOMEBREW_CASK_OPTS

### DIFF
--- a/roles/cask_env_package/defaults/main.yml
+++ b/roles/cask_env_package/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+homebrew_cask_opts: "--appdir=/Applications"

--- a/roles/cask_env_package/meta/main.yml
+++ b/roles/cask_env_package/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: homebrew_cask

--- a/roles/cask_env_package/tasks/main.yml
+++ b/roles/cask_env_package/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# shim for homebrew cask to install to user defined dir
+# works around first run/clean system that don't have their dot-shell patched yet
+- name: wrap homebrew in bash with env
+  command: 'bash -lc "HOMEBREW_CASK_OPTS=\"{{ homebrew_cask_opts }}\"; brew cask install {{ package_name }}"'
+
+- name: warn to source dotfile or start a new term
+  debug: msg="For further runs *in a new shell* use cask_package instead of cask_env_package"


### PR DESCRIPTION
HOMEBREW_CASK_OPTS is missing on a first run or fresh install before user's shell dotfile is patched.  Fixes things going into ~/Applications instead of /Application, lets user specify path from a playbook file, and reminds them to use cask_package in the future.

Totally stolen from rjacoby's fix for similar issue with ruby, see: https://github.com/osxc/xc-common/pull/28
