### PR TITLE
spf13_vim role fixes

### DIFF
--- a/roles/spf13_vim/tasks/main.yml
+++ b/roles/spf13_vim/tasks/main.yml
@@ -9,17 +9,17 @@
 
 # do_backup
 - name: backup .vim
-  command: mv ~/.vim ~/.vim.$(date +%Y%m%d_%s)
+  shell: mv ~/.vim ~/.vim.$(date +%Y%m%d_%s)
   ignore_errors: True
   when: spf13_bound|failed
 
 - name: backup .vimrc
-  command: mv ~/.vimrc ~/.vimrc.$(date +%Y%m%d_%s)
+  shell: mv ~/.vimrc ~/.vimrc.$(date +%Y%m%d_%s)
   ignore_errors: True
   when: spf13_bound|failed
 
 - name: backup .gvimrc
-  command: mv ~/.gvimrc ~/.gvimrc.$(date +%Y%m%d_%s)
+  shell: mv ~/.gvimrc ~/.gvimrc.$(date +%Y%m%d_%s)
   ignore_errors: True
   when: spf13_bound|failed
 

--- a/roles/spf13_vim/tasks/main.yml
+++ b/roles/spf13_vim/tasks/main.yml
@@ -58,7 +58,7 @@
 # setup_vundle
 - name: setup vundle
   command: >
-          vim -u "~/.vimrc.bundles"
+          vim -u "~/.spf13-vim-3/.vimrc.bundles.default"
           "+set nomore"
           +BundleInstall!
           +BundleClean


### PR DESCRIPTION
Fixed some issues I had with the spf13_vim role.

The backup commands were failing:

```
TASK: [spf13_vim | backup .vim] ***********************************************
failed: [localhost] => {"changed": true, "cmd": ["mv", "~/.vim", "~/.vim.`date", "+%Y%m%d_%s`"], "delta": "0:00:00.009557", "end": "2014-06-18 20:06:23.877611", "item": "", "rc": 1, "start": "2014-06-18 20:06:23.868054"}
stderr: mv: target ‘+%Y%m%d_%s`’ is not a directory
...ignoring

TASK: [spf13_vim | backup .vimrc] *********************************************
failed: [localhost] => {"changed": true, "cmd": ["mv", "~/.vimrc", "~/.vimrc.`date", "+%Y%m%d_%s`"], "delta": "0:00:00.003468", "end": "2014-06-18 20:06:23.945563", "item": "", "rc": 1, "start": "2014-06-18 20:06:23.942095"}
stderr: mv: target ‘+%Y%m%d_%s`’ is not a directory
...ignoring

TASK: [spf13_vim | backup .gvimrc] ********************************************
failed: [localhost] => {"changed": true, "cmd": ["mv", "~/.gvimrc", "~/.gvimrc.`date", "+%Y%m%d_%s`"], "delta": "0:00:00.003466", "end": "2014-06-18 20:06:24.012892", "item": "", "rc": 1, "start": "2014-06-18 20:06:24.009426"}
stderr: mv: target ‘+%Y%m%d_%s`’ is not a directory
...ignoring
```

And also updated the setup vundle command to match the [upstream bootstrap script](https://github.com/spf13/spf13-vim/blob/9028b86c7f71176f596f5c382e2d9c8e685241e1/bootstrap.sh#L147).
