### PR TITLE
dock apps with spaces in the App name don't work

### DIFF
--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -8,11 +8,11 @@
   file: path=~/.managed-dock state=touch
 
 - name: add apps
-  shell: "PYTHONIOENCODING=utf-8 {{ dockutil_exe }} --add {{ item }}"
+  shell: "PYTHONIOENCODING=utf-8 {{ dockutil_exe }} --add '{{ item }}'"
   ignore_errors: True
   with_items: apps
 
 - name: add folders
-  shell: "PYTHONIOENCODING=utf-8 {{ dockutil_exe }} --add {{ item.path }} --view {{ item.view|default('grid') }} --display {{ item.display|default('folder') }} --sort {{ item.sort|default('name') }}"
+  shell: "PYTHONIOENCODING=utf-8 {{ dockutil_exe }} --add '{{ item.path }}' --view {{ item.view|default('grid') }} --display {{ item.display|default('folder') }} --sort {{ item.sort|default('name') }}"
   ignore_errors: True
   with_items: folders


### PR DESCRIPTION
For instance, for google chrome I get the following:

failed: [localhost] => (item=~/Applications/Google Chrome.app) =>
{"changed": true, "cmd": "PYTHONIOENCODING=utf-8
~/src/github.com/kcrawford/dockutil/scripts/dockutil --add
~/Applications/Google Chrome.app ", "delta": "0:00:00.038487", "end":
"2014-07-03 10:35:56.220356", "item": "~/Applications/Google
Chrome.app", "rc": 1, "start": "2014-07-03 10:35:56.181869"}

stdout: Chrome.app does not seem to be a home directory or a dock plist
