### PR TITLE
Updated brew_package to support brew Options

### DIFF
--- a/roles/brew_package/tasks/main.yml
+++ b/roles/brew_package/tasks/main.yml
@@ -7,3 +7,8 @@
 
 - name: install {{ package_name }}
   homebrew: name={{ package_name }} state=latest update_homebrew=no
+  when: brew_opts is not defined
+
+- name: install {{ package_name }} with {{ brew_opts }}
+  homebrew: name={{ package_name }} install_options={{ brew_opts }} state=latest update_homebrew=no
+  when: brew_opts is defined


### PR DESCRIPTION
ansible's homebrew module supports install_options, now osxc does too!

usage:
brew_opts: with-opt1,with-opt2  (ie: drop the -- and no spaces)
