### PR TITLE
fixed git_package being broken from missing https://

### DIFF
--- a/roles/git_package/tasks/main.yml
+++ b/roles/git_package/tasks/main.yml
@@ -8,7 +8,7 @@
   register: ssh_remote
 
 - name: clone {{ remote_repo }} to {{ local_repo }}
-  git: repo={{ remote_repo }} dest={{ local_repo }}
+  git: repo=https://{{ remote_repo }} dest={{ local_repo }}
        bare={{ bare }}
        depth={{ depth }}
        executable={{ executable }}


### PR DESCRIPTION
it doesn't work without it, ooops!

left the ssh part as is, as it requires ssh:// in remote_repo to trigger the extra ssh bits.
