### PR TITLE
pip_package supports installing directly from repositories

### DIFF
--- a/roles/pip_package/tasks/main.yml
+++ b/roles/pip_package/tasks/main.yml
@@ -1,3 +1,9 @@
 ---
 - name: install {{ package_name }}
   pip: name={{ package_name }} state=latest
+  when: package_name is defined
+
+- name: install {{ item.egg_name }}
+  shell: /usr/local/bin/pip install --user {{ item.address }}
+  with_items: vcs_eggs
+  when: vcs_eggs is defined


### PR DESCRIPTION
I know it should be better to use pip module from ansible, but I couldn't find the way to install the egg with another name beyond the repository name.
